### PR TITLE
CreateImageUrlBuilder is no longer wrapped by next-sanity.

### DIFF
--- a/sanity.js
+++ b/sanity.js
@@ -1,5 +1,5 @@
 import { createClient, createImageUrlBuilder } from "next-sanity"
-import imageUrlBuilder from '@sanity/image-url'
+import createImageUrlBuilder from '@sanity/image-url'
 
 const config = {
   /**
@@ -22,7 +22,7 @@ const config = {
  * Set up a helper function for generating Image URLs with only the asset reference data in your documents.
  * Read more: https://www.sanity.io/docs/image-url
  **/
-export const urlFor = (source) => imageUrlBuilder(config).image(source)
+export const urlFor = (source) => createImageUrlBuilder(config).image(source)
 
 // Set up the client for fetching data in the getProps page functions
 export const sanityClient = createClient(config)

--- a/sanity.js
+++ b/sanity.js
@@ -1,4 +1,5 @@
 import { createClient, createImageUrlBuilder } from "next-sanity"
+import imageUrlBuilder from '@sanity/image-url'
 
 const config = {
   /**
@@ -21,7 +22,7 @@ const config = {
  * Set up a helper function for generating Image URLs with only the asset reference data in your documents.
  * Read more: https://www.sanity.io/docs/image-url
  **/
-export const urlFor = (source) => createImageUrlBuilder(config).image(source)
+export const urlFor = (source) => imageUrlBuilder(config).image(source)
 
 // Set up the client for fetching data in the getProps page functions
 export const sanityClient = createClient(config)


### PR DESCRIPTION
CreateImageUrlBuilder is no longer wrapped by next-sanity. install the dependency yourself 
https://github.com/sanity-io/next-sanity#createimageurlbuilder-is-removed

```sh
$ npm install @sanity/image-url
```

```diff
-import { createImageUrlBuilder } from 'next-sanity'
+import createImageUrlBuilder from '@sanity/image-url'
```